### PR TITLE
Rename QnA orchestrator

### DIFF
--- a/answer_orchestrator_agent/__init__.py
+++ b/answer_orchestrator_agent/__init__.py
@@ -1,0 +1,2 @@
+from . import agent
+from . import prompts

--- a/answer_orchestrator_agent/agent.py
+++ b/answer_orchestrator_agent/agent.py
@@ -189,7 +189,7 @@ def search_google(query: str) -> str:
 
 from google.adk.agents import InvocationContext
 
-class QnAOrchestratorInput(BaseModel):
+class AnswerOrchestratorInput(BaseModel):
     query: str = Field(..., description="User's question or voice-transcribed input.")
     role: Literal["teacher", "parent", "student"] = Field(..., description="Role of the user.")
     board: str
@@ -230,12 +230,12 @@ processing_agent = SequentialAgent(
     description="Handles RAG retrieval and role-based formatting sequentially"
 )
 
-# --- Step 2: Main Q&A Orchestrator (Clarity Check + Processing) ---
-qna_orchestrator_agent = LlmAgent(
-    name="QnAOrchestratorAgent",
+# --- Step 2: Main Answer Orchestrator (Clarity Check + Processing) ---
+answer_orchestrator_agent = LlmAgent(
+    name="AnswerOrchestratorAgent",
     model=GEMINI_PRO_MODEL,
     instruction="""
-    You are a Q&A orchestrator with clear separation of concerns:
+    You are an answer orchestrator with clear separation of concerns:
 
     1. **First, call ClarifierAgent** to check if the user query is clear.
 
@@ -252,9 +252,9 @@ qna_orchestrator_agent = LlmAgent(
         agent_tool.AgentTool(agent=clarifier_agent),
         agent_tool.AgentTool(agent=processing_agent)
     ],
-    input_schema=QnAOrchestratorInput
+    input_schema=AnswerOrchestratorInput
 )
 
-root_agent = qna_orchestrator_agent
+root_agent = answer_orchestrator_agent
 
 

--- a/answer_orchestrator_agent/prompts.py
+++ b/answer_orchestrator_agent/prompts.py
@@ -1,7 +1,7 @@
-QNA_ORCHESTRATOR_PROMPT = """
-You are a role-aware AI Q&A orchestrator assisting students, parents, and teachers with textbook-based answers.
+ANSWER_ORCHESTRATOR_PROMPT = """
+You are a role-aware AI answer orchestrator assisting students, parents, and teachers with textbook-based answers.
 
-Your job is to decide which tool or agent to call based on the user's role, query, and available data.
+Your job is to decide which tool or agent to call based on the user's role, query, and available data, and return only the final answer.
 
 Follow these control steps:
 

--- a/common_agents/role_formatter_agent.py
+++ b/common_agents/role_formatter_agent.py
@@ -272,7 +272,7 @@ role_formatter_agent = RoleFormatterAgent()
 
 # Usage example for orchestrators:
 """
-# In QnAOrchestratorAgent or QuizPrepOrchestratorAgent:
+# In AnswerOrchestratorAgent or QuizPrepOrchestratorAgent:
 
 from common_agents.role_formatter_agent import role_formatter_agent
 

--- a/q_and_a_orchastrator_agent/__init__.py
+++ b/q_and_a_orchastrator_agent/__init__.py
@@ -1,2 +1,0 @@
-from . import agent
-from . import prompts

--- a/request_processor_agent/agent.py
+++ b/request_processor_agent/agent.py
@@ -3,7 +3,7 @@ from google.adk.tools import agent_tool
 
 from exam_generating_agent_new.agent import root_agent as exam_generating_agent
 from lesson_planning_agent.agent import root_agent as lesson_planning_agent
-from q_and_a_orchastrator_agent.agent import qna_orchestrator_agent
+from answer_orchestrator_agent.agent import answer_orchestrator_agent
 from syllabus_planning_agent.agent import root_agent as syllabus_planning_agent
 from diagram_generating_agent.agent import root_agent as diagram_generating_agent
 from image_generating_agent.agent import root_agent as image_generating_agent
@@ -189,7 +189,7 @@ root_agent = LlmAgent(
     model=GEMINI_FLASH_MODEL,
     instruction=instruction_prompt_root_agent,
     tools=[
-        createToolFromAgent(qna_orchestrator_agent),
+        createToolFromAgent(answer_orchestrator_agent),
         createToolFromAgent(diagram_generating_agent),
         createToolFromAgent(image_generating_agent),
         createToolFromAgent(exam_generating_agent),


### PR DESCRIPTION
## Summary
- rename `q_and_a_orchastrator_agent` package to `answer_orchestrator_agent`
- rename `QnAOrchestratorInput` to `AnswerOrchestratorInput`
- rename agent instance to `answer_orchestrator_agent`
- update `AnswerOrchestratorAgent` prompt and docstrings
- adjust imports and references throughout the repo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821e5c47a48330ba485192b2e1f40a